### PR TITLE
refactor: python 3.10 style typing

### DIFF
--- a/dfaligner/cli.py
+++ b/dfaligner/cli.py
@@ -1,6 +1,5 @@
 from enum import Enum
 from pathlib import Path
-from typing import List
 
 import typer
 from everyvoice.base_cli.interfaces import (
@@ -28,7 +27,7 @@ class PreprocessCategories(str, Enum):
 @app.command()
 @merge_args(preprocess_base_command_interface)
 def preprocess(
-    steps: List[PreprocessCategories] = typer.Option(
+    steps: list[PreprocessCategories] = typer.Option(
         [cat.value for cat in PreprocessCategories],
         "-s",
         "--steps",
@@ -76,7 +75,7 @@ def extract_alignments(
     model_path: Path = typer.Option(
         None, "--model", "-m", exists=True, file_okay=True, dir_okay=False
     ),
-    config_args: List[str] = typer.Option(None, "--config", "-c"),
+    config_args: list[str] = typer.Option(None, "--config", "-c"),
     num_processes: int = typer.Option(None),
     predict: bool = typer.Option(True),
     create_n_textgrids: int = typer.Option(5, "--tg", "--n_textgrids"),

--- a/dfaligner/config/__init__.py
+++ b/dfaligner/config/__init__.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional
 
 from everyvoice.config.preprocessing_config import PreprocessingConfig
 from everyvoice.config.shared_types import (
@@ -32,7 +32,7 @@ class DFAlignerModelConfig(ConfigModel):
 
 
 class DFAlignerTrainingConfig(BaseTrainingConfig):
-    optimizer: Union[AdamOptimizer, AdamWOptimizer] = Field(
+    optimizer: AdamOptimizer | AdamWOptimizer = Field(
         default_factory=AdamWOptimizer,
         description="Optimizer configuration settings.",
     )
@@ -74,7 +74,7 @@ class DFAlignerConfig(PartialLoadConfig):
     path_to_text_config_file: Optional[FilePath] = None
 
     @model_validator(mode="before")  # type: ignore
-    def load_partials(self: Dict[Any, Any], info: ValidationInfo):
+    def load_partials(self: dict[Any, Any], info: ValidationInfo):
         config_path = (
             info.context.get("config_path", None) if info.context is not None else None
         )

--- a/dfaligner/dataset.py
+++ b/dfaligner/dataset.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 from random import Random
-from typing import Dict, List, Optional, Union
+from typing import Optional
 
 import numpy as np
 import pytorch_lightning as pl
@@ -180,7 +180,7 @@ class BinnedLengthSampler(Sampler):
         return len(self.idx)
 
 
-def collate_dataset(batch: List[dict]) -> Dict[str, Union[torch.Tensor, List[str]]]:
+def collate_dataset(batch: list[dict]) -> dict[str, torch.Tensor | list[str]]:
     tokens: torch.Tensor = pad_sequence(
         [b["tokens"] for b in batch], batch_first=True, padding_value=0
     )

--- a/dfaligner/duration_extraction.py
+++ b/dfaligner/duration_extraction.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 import numpy as np
 from scipy.sparse import coo_matrix
 from scipy.sparse.csgraph import dijkstra
@@ -89,7 +87,7 @@ def extract_durations_with_dijkstra(tokens: np.ndarray, pred: np.ndarray) -> np.
 
 def extract_durations_beam(
     tokens: np.ndarray, pred: np.ndarray, k: int
-) -> Tuple[List[np.ndarray], List[List[np.ndarray]]]:
+) -> tuple[list[np.ndarray], list[list[np.ndarray]]]:
     data = pred[:, tokens]
     sequences = [[[0], -np.log(data[0, 0])]]  # always start on first position
     for row in data[1:]:

--- a/dfaligner/utils.py
+++ b/dfaligner/utils.py
@@ -1,6 +1,6 @@
 import pickle
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any
 
 import yaml
 from pympi.Praat import TextGrid
@@ -21,7 +21,7 @@ def create_textgrid(save_path, tokens, durations, hop_size, sample_rate):
     tg.to_file(save_path)
 
 
-def read_metafile(path: str) -> Dict[str, str]:
+def read_metafile(path: str) -> dict[str, str]:
     text_dict = {}
     with open(path, encoding="utf-8") as f:
         for line in f:
@@ -31,27 +31,27 @@ def read_metafile(path: str) -> Dict[str, str]:
     return text_dict
 
 
-def read_config(path: str) -> Dict[str, Any]:
+def read_config(path: str) -> dict[str, Any]:
     with open(path, "r") as stream:
         config = yaml.load(stream, Loader=yaml.FullLoader)
     return config
 
 
-def save_config(config: Dict[str, Any], path: str) -> None:
+def save_config(config: dict[str, Any], path: str) -> None:
     with open(path, "w+", encoding="utf-8") as stream:
         yaml.dump(config, stream, default_flow_style=False)
 
 
-def get_files(path: str, extension=".wav") -> List[Path]:
+def get_files(path: str, extension=".wav") -> list[Path]:
     return list(Path(path).expanduser().resolve().rglob(f"*{extension}"))
 
 
-def pickle_binary(data: object, file: Union[str, Path]) -> None:
+def pickle_binary(data: object, file: str | Path) -> None:
     with open(str(file), "wb") as f:
         pickle.dump(data, f)
 
 
-def unpickle_binary(file: Union[str, Path]) -> Any:
+def unpickle_binary(file: str | Path) -> Any:
     with open(str(file), "rb") as f:
         return pickle.load(f)
 


### PR DESCRIPTION
I think at this point it's safe to my refactoring work back in, changing all the Union, Dict and List to |, dict and list.